### PR TITLE
update glossarist to version 2

### DIFF
--- a/termium.gemspec
+++ b/termium.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "glossarist", "~> 1.0"
+  spec.add_dependency "glossarist", "~> 2.0"
   spec.add_dependency "shale"
   spec.add_dependency "thor"
 


### PR DESCRIPTION
Update the `gemspec` to use glossarist V2.

closes metanorma/iso-iec-2382#24