### PR TITLE
set compatible glossarist version

### DIFF
--- a/termium.gemspec
+++ b/termium.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "glossarist", "~> 2.2"
+  spec.add_dependency "glossarist", "~> 2.2.0"
   spec.add_dependency "lutaml-model"
   spec.add_dependency "thor"
   spec.add_dependency "uuidtools"


### PR DESCRIPTION
This PR fixes `termium` CI workflow failing for `dependent-gems` in `LutaML-model` gem
Example CI run: https://github.com/lutaml/lutaml-model/actions/runs/13027757968