### PR TITLE
fix specs after lutaml-model performance improvement

### DIFF
--- a/lib/termium/entry_term.rb
+++ b/lib/termium/entry_term.rb
@@ -10,7 +10,7 @@ module Termium
   class EntryTerm < Lutaml::Model::Serializable
     attribute :order, :integer
     attribute :value, :string
-    attribute :source_ref, SourceRef
+    attribute :source_ref, SourceRef, collection: true
     attribute :abbreviation, Abbreviation, collection: true
     attribute :parameter, Parameter, collection: true
     include DesignationOperations


### PR DESCRIPTION
The specs are failing in ci of `lutaml-model` in its performance improvement branch  [here](https://github.com/lutaml/lutaml-model/actions/runs/13201195796/job/36853690632) because `collection: true` is missing in `EntryTerm`
Example snippet from specs fixtures:

```
...
<languageModule language="EN">
    <entryTerm order="1" value="character">
      <sourceRef order="1"/>
      <sourceRef order="2"/>
      <parameter abbreviation="COR"/>
      <parameter abbreviation="NORM"/>
    </entryTerm>
</languageModule>
...
```
Hence, `sourceRef` can occur multiple times in XML so it should be a `collection` just like `parameter` element
