### PR TITLE
fix: for lutaml model version 0.7

### DIFF
--- a/lib/termium/core.rb
+++ b/lib/termium/core.rb
@@ -70,7 +70,7 @@ module Termium
           localized_concept.uuid = uuid("#{identification_number}-#{lang_mod.language}")
 
           universal_entry.each do |entry|
-            localized_concept.notes << entry.value
+            localized_concept.notes << Glossarist::DetailedDefinition.new(content: entry.value)
           end
           localized_concept.sources = concept_sources
           concept.add_localization(localized_concept)

--- a/lib/termium/entry_term.rb
+++ b/lib/termium/entry_term.rb
@@ -18,7 +18,7 @@ module Termium
     xml do
       root "entryTerm"
       map_attribute "order", to: :order
-      map_attribute "value", to: :value
+      map_attribute "value", to: :value, value_map: { to: { empty: :empty } }
       map_element "sourceRef", to: :source_ref
       map_element "parameter", to: :parameter
       map_element "abbreviation", to: :abbreviation

--- a/termium.gemspec
+++ b/termium.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "glossarist", "~> 2.2.0"
-  spec.add_dependency "lutaml-model"
+  spec.add_dependency "lutaml-model", "~> 0.7"
   spec.add_dependency "thor"
   spec.add_dependency "uuidtools"
 end

--- a/termium.gemspec
+++ b/termium.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "glossarist", "~> 2.2.0"
-  spec.add_dependency "lutaml-model", "~> 0.7"
+  spec.add_dependency "glossarist", "~> 2.3.5"
+  spec.add_dependency "lutaml-model", "~> 0.7.1"
   spec.add_dependency "thor"
   spec.add_dependency "uuidtools"
 end


### PR DESCRIPTION
Fixes for lutaml-model version 0.7

Should merge this once https://github.com/lutaml/lutaml-model/pull/357 and https://github.com/glossarist/glossarist-ruby/pull/125 are merged and version 0.7 is released for lutaml-model.